### PR TITLE
Losening constraint on elixir.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule YYID.Mixfile do
   def project do
     [app: :yyid,
      version: "0.1.0",
-     elixir: "~> 0.14.3",
+     elixir: "~> 0.14",
      deps: [],
      package: package,
      description: description]


### PR DESCRIPTION
Changed the current version constraint on elixir from ">=0.14.3 && < 0.15.0" to  ">=0.14 && < 1.0.0" , so it can be installed with the latest non stable version of elixir.
